### PR TITLE
Clear cache after deleting log file

### DIFF
--- a/src/Http/Livewire/FileList.php
+++ b/src/Http/Livewire/FileList.php
@@ -39,6 +39,8 @@ class FileList extends Component
             $this->selectedFileName = '';
             $this->emit('fileSelected', $this->selectedFileName);
         }
+        
+        LogViewer::getFiles()->each->clearIndexCache();
     }
 
     public function clearCache(string $fileName)

--- a/src/Http/Livewire/FileList.php
+++ b/src/Http/Livewire/FileList.php
@@ -39,8 +39,6 @@ class FileList extends Component
             $this->selectedFileName = '';
             $this->emit('fileSelected', $this->selectedFileName);
         }
-        
-        LogViewer::getFiles()->each->clearIndexCache();
     }
 
     public function clearCache(string $fileName)

--- a/src/LogFile.php
+++ b/src/LogFile.php
@@ -58,6 +58,7 @@ class LogFile
     public function delete()
     {
         unlink($this->path);
+        $this->clearIndexCache();
         LogFileDeleted::dispatch($this);
     }
 }


### PR DESCRIPTION
Hello, I have noticed if you delete a log file and produce new logs, the new logs won't appear, logs count won't reset even upon refreshing the browser, quick soln I've found is clearing the cache for all files option.

Kindly validate.