### PR TITLE
Sub Folder Extraction bug fixed

### DIFF
--- a/src/LogFile.php
+++ b/src/LogFile.php
@@ -20,7 +20,7 @@ class LogFile
 
         // by default, we load all logs from the storage/logs folder, so we can
         // safely disregard that part because it's always going to be the same.
-        $folder = str_replace(Str::finish(storage_path('logs'), '/'), '', $path);
+        $folder = str_replace(Str::finish(storage_path('logs'), DIRECTORY_SEPARATOR), '', $path);
 
         // now we're left with something like `folderA/laravel.log`. Let's remove the file name because we already know it.
         $this->subFolder = str_replace($name, '', $folder);

--- a/src/LogViewerService.php
+++ b/src/LogViewerService.php
@@ -5,6 +5,7 @@ namespace Opcodes\LogViewer;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Str;
 
 class LogViewerService
 {
@@ -21,11 +22,11 @@ class LogViewerService
         $files = [];
 
         foreach (config('log-viewer.include_files', []) as $pattern) {
-            $files = array_merge($files, glob(storage_path().'/logs/'.$pattern));
+            $files = array_merge($files, glob(Str::finish(storage_path('logs'), DIRECTORY_SEPARATOR).$pattern));
         }
 
         foreach (config('log-viewer.exclude_files', []) as $pattern) {
-            $files = array_diff($files, glob(storage_path().'/logs/'.$pattern));
+            $files = array_diff($files, glob(Str::finish(storage_path('logs'), DIRECTORY_SEPARATOR).$pattern));
         }
 
         $files = array_reverse($files);


### PR DESCRIPTION
Fixed the bug where in windows the subfolder extraction wouldn't work and the entire path will be taken for the subfolder. 

Before: | After
---|---
![image](https://user-images.githubusercontent.com/21041099/188132319-2bcba1ef-afba-4efc-804b-9158d807b7bc.png) | ![image](https://user-images.githubusercontent.com/21041099/188142700-c116fae1-8253-49ae-ad46-b0d7a5f6813c.png)
