### PR TITLE
Changed the way LogViewer retrieve the package version

### DIFF
--- a/src/Http/Livewire/LogList.php
+++ b/src/Http/Livewire/LogList.php
@@ -2,6 +2,7 @@
 
 namespace Opcodes\LogViewer\Http\Livewire;
 
+use Composer\InstalledVersions;
 use Illuminate\Support\Str;
 use Livewire\Component;
 use Livewire\WithPagination;
@@ -79,13 +80,8 @@ class LogList extends Component
         $startTime = defined('LARAVEL_START') ? LARAVEL_START : request()->server('REQUEST_TIME_FLOAT');
 
         $memoryUsage = number_format(memory_get_peak_usage(true) / 1024 / 1024, 2).' MB';
+        $version = InstalledVersions::getPrettyVersion('opcodesio/log-viewer');
         $requestTime = number_format((microtime(true) - $startTime) * 1000, 0).'ms';
-        try {
-            $version = json_decode(file_get_contents(__DIR__.'/../../../composer.json'))?->version ?? null;
-        } catch (\Exception $e) {
-            // Could not get the version from the composer file for some reason. Let's ignore that and move on.
-            $version = null;
-        }
 
         return view('log-viewer::livewire.log-list', [
             'file' => $file,


### PR DESCRIPTION
Used the composer class methods to fetch the version of the package. Read more about it [here](https://getcomposer.org/doc/07-runtime.md#knowing-a-package-s-own-installed-version)

Advantage
- Will show the deployed branch of the package, even while using `dev-main`, instead of the version in the `composer.json` file
- This will help in debugging purposes as well

I have done a small benchmark here and the suggested version seems to work a bit faster than the try catch. Not sure how much will it hold when there are a lot of dependencies in the core application though. Also, in the image, you can see I am using the `dev-main` branch directly from the composer to see how it looks in those scenarios. 

![image](https://user-images.githubusercontent.com/21041099/188189549-42b0e9f9-446a-42e6-ac80-a57efab6cebc.png)
