### PR TITLE
fix for download route authorization

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -20,6 +20,8 @@ Route::middleware(LogViewer::getRouteMiddleware())
         })->name('blv.index');
 
         Route::get('file/{fileIdentifier}/download', function (string $fileIdentifier) {
+            LogViewer::auth();
+            
             $file = LogViewer::getFile($fileIdentifier);
 
             abort_if(is_null($file), 404);


### PR DESCRIPTION
Authorization via "auth" callback doesn't work for file download routes. Users can download log files even if they are not authorized.