### PR TITLE
Allow route domains

### DIFF
--- a/config/log-viewer.php
+++ b/config/log-viewer.php
@@ -6,6 +6,17 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Log Viewer Domain
+    |--------------------------------------------------------------------------
+    | You may change the domain where Log Viewer should be active.
+    | If the domain is empty, all domains will be valid.
+    |
+    */
+
+    'route_domain' => null,
+
+    /*
+    |--------------------------------------------------------------------------
     | Log Viewer Route
     |--------------------------------------------------------------------------
     | Log Viewer will be available under this URL.

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,7 +4,8 @@ use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Route;
 use Opcodes\LogViewer\Facades\LogViewer;
 
-Route::middleware(LogViewer::getRouteMiddleware())
+Route::domain(LogViewer::getRouteDomain())
+    ->middleware(LogViewer::getRouteMiddleware())
     ->prefix(LogViewer::getRoutePrefix())
     ->group(function () {
         Route::get('/', function () {

--- a/src/Facades/LogViewer.php
+++ b/src/Facades/LogViewer.php
@@ -13,6 +13,7 @@ use Opcodes\LogViewer\LogFile;
  * @method static LogFile[]|Collection getFiles()
  * @method static LogFile|null getFile(string $fileIdentifier)
  * @method static void clearFileCache()
+ * @method static string|null getRouteDomain()
  * @method static array getRouteMiddleware()
  * @method static string getRoutePrefix()
  * @method static void auth($callback = null)

--- a/src/LogViewerService.php
+++ b/src/LogViewerService.php
@@ -96,6 +96,11 @@ class LogViewerService
         $this->_cachedFiles = null;
     }
 
+    public function getRouteDomain(): ?string
+    {
+        return config('log-viewer.route_domain');
+    }
+
     public function getRoutePrefix(): string
     {
         return config('log-viewer.route_path', 'log-viewer');

--- a/tests/Feature/RoutesTest.php
+++ b/tests/Feature/RoutesTest.php
@@ -20,6 +20,18 @@ test('the default url can be changed', function () {
     get(route('blv.index'))->assertOK();
 });
 
+test('a domain can be set', function () {
+    config()->set('log-viewer.route_domain', 'logs.domain.test');
+    config()->set('log-viewer.route_path', '/');
+
+    reloadRoutes();
+
+    expect(route('blv.index'))->toBe('http://logs.domain.test');
+
+    get(route('blv.index'))->assertOK();
+});
+
+
 /*
 |--------------------------------------------------------------------------
 | HELPERS


### PR DESCRIPTION
This PR allows LogViewer to be served under a subdomain e.g. `https://logs.myapp.com`

Thank you. 🙏