### PR TITLE
Multi-select delete feature added

### DIFF
--- a/resources/views/livewire/file-list.blade.php
+++ b/resources/views/livewire/file-list.blade.php
@@ -98,6 +98,9 @@
             </div>
 
             <div class="folder-files pl-3 ml-1 border-l border-gray-200 dark:border-gray-800" x-show="$store.fileViewer.isOpen(folder)">
+            <button x-on:click.stop="if (confirm('Are you sure you want to delete selected log files? THIS ACTION CANNOT BE UNDONE.')) { $wire.call('deleteMultipleFiles') }" class="py-4 inline-flex  @if(!$selectedFilesArray->count()) hidden @endif">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" class="w-5" fill="currentColor"><use href="#icon-trashcan" /></svg>&nbsp;<small>Delete Selected Files</small>
+            </button>
             @foreach($folder->files() as $logFile)
                 @include('log-viewer::partials.file-list-item', ['logFile' => $logFile])
             @endforeach

--- a/resources/views/partials/file-list-item.blade.php
+++ b/resources/views/partials/file-list-item.blade.php
@@ -1,3 +1,7 @@
+<div class="inline-flex">
+    @can('deleteLogFile', $logFile)
+    <span class="mt-3 pr-2"><input type="checkbox" @if($selectedFilesArray->contains($logFile->identifier)) checked @endif class="form-control" value="{{$logFile->identifier}}" wire:click="selectMultipleFiles('{{$logFile->identifier}}')"></span>
+    @endcan
 <div class="file-item-container"
     x-bind:class="[selectedFileIdentifier && selectedFileIdentifier === '{{ $logFile->identifier }}' ? 'active' : '']"
     wire:key="log-file-{{$logFile->identifier}}"
@@ -52,4 +56,5 @@
             @endcan
         </div>
     </div>
+</div>
 </div>

--- a/src/Http/Livewire/FileList.php
+++ b/src/Http/Livewire/FileList.php
@@ -19,6 +19,8 @@ class FileList extends Component
 
     public ?string $selectedFileIdentifier = null;
 
+    public $selectedFilesArray = null;
+
     public string $direction = self::NEWEST_FIRST;
 
     protected bool $cacheRecentlyCleared;
@@ -29,6 +31,7 @@ class FileList extends Component
         $this->direction = $preferenceStore->get('file_sort_direction', self::NEWEST_FIRST);
 
         $this->selectedFileIdentifier = $selectedFileIdentifier;
+        $this->selectedFilesArray = collect([]);
 
         if (! LogViewer::getFile($this->selectedFileIdentifier)) {
             $this->selectedFileIdentifier = null;
@@ -61,6 +64,25 @@ class FileList extends Component
     public function selectFile(string $name)
     {
         $this->selectedFileIdentifier = $name;
+    }
+
+    public function selectMultipleFiles(string $name)
+    {
+        if ($this->selectedFilesArray->contains($name)) {
+            $this->selectedFilesArray = $this->selectedFilesArray->reject(function ($value) use ($name) {
+                return $value == $name;
+            });
+        } else {
+            $this->selectedFilesArray->push($name);
+        }
+    }
+
+    public function deleteMultipleFiles()
+    {
+        foreach($this->selectedFilesArray as $fileIdentifier){
+            $this->deleteFile($fileIdentifier);
+        }
+        $this->selectedFilesArray = collect([]);
     }
 
     public function deleteFile(string $fileIdentifier)


### PR DESCRIPTION
Sometimes people want to delete specified multiple log files at once instead of deleting them one by one (a time-consuming operation). Multi-select delete feature can help in this scenario.

![multi-select-delete](https://user-images.githubusercontent.com/40138376/201381846-e1351231-022a-42c0-a255-fe79c35e5ed8.gif)
