### PR TITLE
Fix null parameter deprecation

### DIFF
--- a/src/Concerns/LogIndex/CanFilterIndex.php
+++ b/src/Concerns/LogIndex/CanFilterIndex.php
@@ -56,7 +56,7 @@ trait CanFilterIndex
         }
 
         if (is_array($levels)) {
-            $this->filterLevels = array_map('strtolower', $levels);
+            $this->filterLevels = array_map('strtolower', array_filter($levels));
         } else {
             $this->filterLevels = null;
         }


### PR DESCRIPTION
When using PHP 8.1, it constantly throws the deprecation log on the Log display screen.

![warning](https://user-images.githubusercontent.com/4013224/220326832-2a51975d-fa82-4b14-8328-8f129f23c053.gif)
