### PR TITLE
Addition to README about composer.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,16 @@ After installing the package, publish the front-end assets by running:
 php artisan log-viewer:publish
 ```
 
+This command should also be appended to the list of post-update commands in your `composer.json`:
+
+```bash
+"post-update-cmd": [
+    "Illuminate\\Foundation\\ComposerScripts::postUpdate",
+    // ...
+    "@php artisan log-viewer:publish"
+],
+```
+
 ### Usage
 
 Once the installation is complete, you will be able to access **Log Viewer** directly in your browser.


### PR DESCRIPTION
I updated to the latest package version and I noticed errors. I had forgotten to run `php artisan log-viewer:publish` after updating.

I think this command should be added to the `post-update-cmd` array in `composer.json` to prevent bugs in case someone forgets to run it, so I added it to the README.