### PR TITLE
Fixed issue with search API optional parameters

### DIFF
--- a/resources/js/stores/logViewer.js
+++ b/resources/js/stores/logViewer.js
@@ -201,8 +201,8 @@ export const useLogViewerStore = defineStore({
         query: searchStore.query,
         page: paginationStore.currentPage,
         per_page: this.resultsPerPage,
-        exclude_levels: toRaw(severityStore.excludedLevels),
-        exclude_file_types: toRaw(fileStore.fileTypesExcluded),
+        exclude_levels: toRaw(severityStore.excludedLevels.length > 0 ? severityStore.excludedLevels : ''),
+        exclude_file_types: toRaw(fileStore.fileTypesExcluded.length > 0 ? fileStore.fileTypesExcluded : ''),
         shorter_stack_traces: this.shorterStackTraces,
       };
 

--- a/resources/js/stores/logViewer.js
+++ b/resources/js/stores/logViewer.js
@@ -201,8 +201,8 @@ export const useLogViewerStore = defineStore({
         query: searchStore.query,
         page: paginationStore.currentPage,
         per_page: this.resultsPerPage,
-        exclude_levels: toRaw(severityStore.excludedLevels.length > 0 ? severityStore.excludedLevels : ''),
-        exclude_file_types: toRaw(fileStore.fileTypesExcluded.length > 0 ? fileStore.fileTypesExcluded : ''),
+        exclude_levels: toRaw(severityStore.excludedLevels),
+        exclude_file_types: toRaw(fileStore.fileTypesExcluded),
         shorter_stack_traces: this.shorterStackTraces,
       };
 

--- a/src/Http/Controllers/LogsController.php
+++ b/src/Http/Controllers/LogsController.php
@@ -22,8 +22,8 @@ class LogsController
         $query = $request->query('query', '');
         $direction = $request->query('direction', 'desc');
         $log = $request->query('log', null);
-        $excludedLevels = $request->query('exclude_levels', []);
-        $excludedFileTypes = $request->query('exclude_file_types', []);
+        $excludedLevels = array_filter((array) $request->query('exclude_levels'));
+        $excludedFileTypes = array_filter((array) $request->query('exclude_file_types'));
         $perPage = $request->query('per_page', 25);
         session()->put('log-viewer:shorter-stack-traces', $request->boolean('shorter_stack_traces', false));
         $hasMoreResults = false;

--- a/src/Http/Controllers/LogsController.php
+++ b/src/Http/Controllers/LogsController.php
@@ -22,8 +22,8 @@ class LogsController
         $query = $request->query('query', '');
         $direction = $request->query('direction', 'desc');
         $log = $request->query('log', null);
-        $excludedLevels = array_filter((array) $request->query('exclude_levels'));
-        $excludedFileTypes = array_filter((array) $request->query('exclude_file_types'));
+        $excludedLevels = $request->query('exclude_levels', []);
+        $excludedFileTypes = $request->query('exclude_file_types', []);
         $perPage = $request->query('per_page', 25);
         session()->put('log-viewer:shorter-stack-traces', $request->boolean('shorter_stack_traces', false));
         $hasMoreResults = false;


### PR DESCRIPTION
Dear Developers,

Thank you for the project! :rocket:

Please consider checking out this light fix regarding the issue which results in the following exception if no file nor any severity is selected:

```
Cannot assign string to property Opcodes\LogViewer\Readers\MultipleLogReader::$exceptLevels of type ?array {"exception":"[object] (TypeError(code: 0): Cannot assign string to property Opcodes\\LogViewer\\Readers\\MultipleLogReader::$exceptLevels of type ?array at /var/www/html/vendor/opcodesio/log-viewer/src/Readers/MultipleLogReader.php:39)
[stacktrace]
#0 /var/www/html/vendor/opcodesio/log-viewer/src/Http/Controllers/LogsController.php(66): Opcodes\\LogViewer\\Readers\\MultipleLogReader->exceptLevels('')
#1 /var/www/html/vendor/laravel/framework/src/Illuminate/Routing/ControllerDispatcher.php(46): Opcodes\\LogViewer\\Http\\Controllers\\LogsController->index(Object(Illuminate\\Http\\Request))
#2 /var/www/html/vendor/laravel/framework/src/Illuminate/Routing/Route.php(260): Illuminate\\Routing\\ControllerDispatcher->dispatch(Object(Illuminate\\Routing\\Route), Object(Opcodes\\LogViewer\\Http\\Controllers\\LogsController), 'index')
```

Possibly, the issue is related to #273.

Best and kind regards :sparkles: