### PR TITLE
fix: cant delete folder when some file locking

### DIFF
--- a/src/Http/Controllers/FoldersController.php
+++ b/src/Http/Controllers/FoldersController.php
@@ -71,7 +71,11 @@ class FoldersController
 
         $folder->files()->each(function (LogFile $file) {
             if (Gate::check('deleteLogFile', $file)) {
-                $file->delete();
+                try {
+                    $file->delete();
+                } catch (Throwable $throwable) {
+                    // ignore
+                }
             }
         });
 


### PR DESCRIPTION
If first file in folder has been lock, It throw exception, I cant delete other file