### PR TITLE
Fix Request failed with status code 500: Undefined array key 1 error when searching

### DIFF
--- a/src/Logs/LaravelLog.php
+++ b/src/Logs/LaravelLog.php
@@ -38,7 +38,7 @@ class LaravelLog extends Log
 
         preg_match(static::regexPattern(), array_shift($firstLineSplit), $matches);
 
-        $this->datetime = Carbon::parse($matches[1])?->setTimezone(LogViewer::timezone());
+        $this->datetime = Carbon::parse($matches[1] ?? null)?->setTimezone(LogViewer::timezone());
 
         // $matches[2] contains microseconds, which is already handled
         // $matches[3] contains timezone offset, which is already handled
@@ -51,7 +51,7 @@ class LaravelLog extends Log
 
         $this->level = strtoupper($matches[6] ?? '');
 
-        $firstLineText = $matches[7];
+        $firstLineText = $matches[7] ?? null;
 
         if (! empty($middle)) {
             $firstLineText = $middle.' '.$firstLineText;


### PR DESCRIPTION
When searching in a certain log file for a specific term, sometimes I get the following messages: Request failed with status code 500: Undefined array key 1.

It seems that in somes cases, index 1 of array variable $matches is not defined. If I make a eval of $matches[1], then the errors occurs in $matches[7].

$matches[1] and $matches[7] are now beeing evaluated.