### PR TITLE
Api stateful domains config option

### DIFF
--- a/config/log-viewer.php
+++ b/config/log-viewer.php
@@ -88,7 +88,7 @@ return [
         \Opcodes\LogViewer\Http\Middleware\AuthorizeLogViewer::class,
     ],
 
-    'api_stateful_domains' => null,
+    'api_stateful_domains' => env('LOG_VIEWER_API_STATEFUL_DOMAINS') ? explode(',', env('LOG_VIEWER_API_STATEFUL_DOMAINS')) : null,
 
     /*
     |--------------------------------------------------------------------------

--- a/config/log-viewer.php
+++ b/config/log-viewer.php
@@ -88,6 +88,8 @@ return [
         \Opcodes\LogViewer\Http\Middleware\AuthorizeLogViewer::class,
     ],
 
+    'api_stateful_domains' => null,
+
     /*
     |--------------------------------------------------------------------------
     | Log Viewer Remote hosts.

--- a/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
+++ b/src/Http/Middleware/EnsureFrontendRequestsAreStateful.php
@@ -70,7 +70,7 @@ class EnsureFrontendRequestsAreStateful
         $domain = Str::replaceFirst('http://', '', $domain);
         $domain = Str::endsWith($domain, '/') ? $domain : "{$domain}/";
 
-        $stateful = array_filter(config('sanctum.stateful', self::defaultStatefulDomains()));
+        $stateful = array_filter(config('log-viewer.api_stateful_domains') ?? config('sanctum.stateful') ?? self::defaultStatefulDomains());
 
         return Str::is(Collection::make($stateful)->map(function ($uri) {
             return trim($uri).'/*';


### PR DESCRIPTION
In a project that runs on 2 domains, I had an issue where the log-viewer API calls failed and caused an 'this action is unauthorized' on the secondary domain. After some digging, I found that I needed to set the `sanctum.stateful` config option. The problem is that my project does not use Sanctum. I had to create a dummy `sanctum.php` config to create and set that config variable.

That's why I propose to make that an option in the log-viewer config so that it can be easily customized even when you don't use Sanctum in your project.

I made the change a non-breaking change by still checking and using `config('sanctum.stateful')` if the `config('log-viewer.api_stateful_domains')` is not set.
