### PR TITLE
API only config

### DIFF
--- a/config/log-viewer.php
+++ b/config/log-viewer.php
@@ -12,6 +12,8 @@ return [
 
     'enabled' => env('LOG_VIEWER_ENABLED', true),
 
+    'api_only' => env('LOG_VIEWER_API_ONLY', false),
+
     'require_auth_in_production' => true,
 
     /*

--- a/src/LogViewerServiceProvider.php
+++ b/src/LogViewerServiceProvider.php
@@ -95,6 +95,10 @@ class LogViewerServiceProvider extends ServiceProvider
             $this->loadRoutesFrom(self::basePath('/routes/api.php'));
         });
 
+        if (config('log-viewer.api_only', false)) {
+            return;
+        }
+
         Route::group([
             'domain' => config('log-viewer.route_domain', null),
             'prefix' => config('log-viewer.route_path'),

--- a/tests/DeferPackageProviderTestCase.php
+++ b/tests/DeferPackageProviderTestCase.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Opcodes\LogViewer\Tests;
+
+use Illuminate\Foundation\Support\Providers\RouteServiceProvider;
+
+class DeferPackageProviderTestCase extends TestCase
+{
+    protected function getPackageProviders($app)
+    {
+        return [
+            RouteServiceProvider::class,
+        ];
+    }
+}

--- a/tests/Feature/OnlyApiRoutesTest.php
+++ b/tests/Feature/OnlyApiRoutesTest.php
@@ -1,0 +1,13 @@
+<?php
+
+use Opcodes\LogViewer\LogViewerServiceProvider;
+use Opcodes\LogViewer\Tests\DeferPackageProviderTestCase;
+use Symfony\Component\Routing\Exception\RouteNotFoundException;
+
+uses(DeferPackageProviderTestCase::class);
+
+test('only has api routes', function () {
+    config(['log-viewer.api_only' => true]);
+    $this->app->register(LogViewerServiceProvider::class);
+    route('log-viewer.index');
+})->throws(RouteNotFoundException::class);

--- a/tests/Feature/RoutesTest.php
+++ b/tests/Feature/RoutesTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Symfony\Component\Routing\Exception\RouteNotFoundException;
+
 test('the default url can be changed', function () {
     config()->set('log-viewer.route_path', 'new-log-route');
 
@@ -19,6 +21,22 @@ test('a domain can be set', function () {
 
 test('a domain is optional', function () {
     config()->set('log-viewer.route_path', '/');
+
+    reloadRoutes();
+
+    expect(route('log-viewer.index'))->toBe('http://localhost');
+});
+
+test('only use api', function () {
+    config()->set('log-viewer.api_only', true);
+
+    reloadRoutes();
+
+    route('log-viewer.index');
+})->throws(RouteNotFoundException::class);
+
+test('only both api and web', function () {
+    config()->set('log-viewer.api_only', false);
 
     reloadRoutes();
 

--- a/tests/Feature/RoutesTest.php
+++ b/tests/Feature/RoutesTest.php
@@ -1,7 +1,5 @@
 <?php
 
-use Symfony\Component\Routing\Exception\RouteNotFoundException;
-
 test('the default url can be changed', function () {
     config()->set('log-viewer.route_path', 'new-log-route');
 
@@ -21,22 +19,6 @@ test('a domain can be set', function () {
 
 test('a domain is optional', function () {
     config()->set('log-viewer.route_path', '/');
-
-    reloadRoutes();
-
-    expect(route('log-viewer.index'))->toBe('http://localhost');
-});
-
-test('only use api', function () {
-    config()->set('log-viewer.api_only', true);
-
-    reloadRoutes();
-
-    route('log-viewer.index');
-})->throws(RouteNotFoundException::class);
-
-test('only both api and web', function () {
-    config()->set('log-viewer.api_only', false);
 
     reloadRoutes();
 

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -11,6 +11,7 @@ use Opcodes\LogViewer\Tests\TestCase;
 uses(TestCase::class)->in(__DIR__);
 uses()->afterEach(fn () => clearGeneratedLogFiles())->in('Feature', 'Unit');
 uses()->beforeEach(fn () => Artisan::call('log-viewer:publish'))->in('Feature');
+uses()->beforeEach(fn () => Artisan::call('config:cache'))->in('Feature');
 uses()->beforeEach(function () {
     // let's not include any of the default mac logs or similar
     config(['log-viewer.include_files' => ['*.log', '**/*.log']]);


### PR DESCRIPTION
This PR introduces the api only config to avoid registering viewer route. Sometimes, I don't want to use the viewer so I had set its default value is `false`.
Usage:
Add `LOG_VIEWER_API_ONLY=true` to `.env`