### PR TITLE
don't publish on laravel-assets namespace

### DIFF
--- a/src/LogViewerServiceProvider.php
+++ b/src/LogViewerServiceProvider.php
@@ -114,7 +114,7 @@ class LogViewerServiceProvider extends ServiceProvider
     {
         $this->publishes([
             self::basePath('/public') => public_path('vendor/log-viewer'),
-        ], ['log-viewer-assets', 'laravel-assets']);
+        ], 'log-viewer-assets');
     }
 
     protected function defineDefaultGates()


### PR DESCRIPTION
I'm confident the `laravel-assets` namespace for assets is really meant for framework stuff.

If kept like this, we'll get double publication of the assets.

<img width="1217" alt="Scherm­afbeelding 2024-04-08 om 20 14 38" src="https://github.com/opcodesio/log-viewer/assets/6680176/73d2030e-009e-4a05-b88a-2a9ebc484147">
