### PR TITLE
Fix PCRE stack limit for context parsing, omitting preg

### DIFF
--- a/src/Logs/LaravelLog.php
+++ b/src/Logs/LaravelLog.php
@@ -109,7 +109,7 @@ class LaravelLog extends Log
         $contexts = [];
 
         // Find matches.
-        $json_strings = $this->getJsonStrings();
+        $json_strings = $this->getJsonStringsFromFullText();
 
         if (empty($json_strings)) {
             return;
@@ -180,7 +180,7 @@ class LaravelLog extends Log
         ];
     }
 
-    protected function getJsonStrings(): array
+    protected function getJsonStringsFromFullText(): array
     {
         $json = '';
         $json_strings = [];


### PR DESCRIPTION
#369 

Fixes issue with silent preg_match_all failure on parsing of long JSON contexts from log text, avoiding JIT Stack Limit due to recursion.