### PR TITLE
Do not export npm dependencies file in the Composer archive

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -15,5 +15,8 @@
 /psalm.xml.dist     export-ignore
 /testbench.yaml     export-ignore
 /UPGRADING.md       export-ignore
+/package.json       export-ignore
+/package-lock.json  export-ignore
 /phpstan.neon.dist  export-ignore
 /phpstan-baseline.neon  export-ignore
+


### PR DESCRIPTION
Since publishing the assets will only include the bundle, I could see the package.json and package-lock.json not being present in the vendor folder after package installation.

WDYT @arukompas ?