### PR TITLE
Make it possible to exclude "full_text" from logs API response

### DIFF
--- a/src/Http/Resources/LogResource.php
+++ b/src/Http/Resources/LogResource.php
@@ -14,8 +14,9 @@ class LogResource extends JsonResource
     public function toArray($request): array
     {
         $level = $this->getLevel();
+        $excludeFullText = $request->boolean('exclude_full_text', false);
 
-        return [
+        $data = [
             'index' => $this->index,
             'file_identifier' => $this->fileIdentifier,
             'file_position' => $this->filePosition,
@@ -30,8 +31,13 @@ class LogResource extends JsonResource
             'context' => $this->context,
             'extra' => $this->extra,
 
-            'full_text' => $this->getOriginalText(),
             'url' => $this->url(),
         ];
+
+        if (! $excludeFullText) {
+            $data['full_text'] = $this->getOriginalText();
+        }
+
+        return $data;
     }
 }

--- a/tests/Feature/Authorization/CanDownloadFoldersTest.php
+++ b/tests/Feature/Authorization/CanDownloadFoldersTest.php
@@ -21,8 +21,8 @@ function assertCanDownloadFolder(string $folderName, string $expectedFileName): 
 
 function assertCannotDownloadFolder(string $folderName): void
 {
-get(route('log-viewer.folders.request-download', $folderName))
-->assertForbidden();
+    get(route('log-viewer.folders.request-download', $folderName))
+        ->assertForbidden();
 }
 
 test('can download every folder by default', function () {
@@ -33,9 +33,9 @@ test('can download every folder by default', function () {
 });
 
 test('cannot download a folder that\'s not found', function () {
-get(route('log-viewer.folders.request-download', 'notfound'))
-->assertNotFound();
-    });
+    get(route('log-viewer.folders.request-download', 'notfound'))
+        ->assertNotFound();
+});
 
 test('"downloadLogFolder" gate can prevent folder download', function () {
     generateLogFiles([$fileName = 'laravel.log']);

--- a/tests/Feature/Authorization/CanDownloadLogFileTest.php
+++ b/tests/Feature/Authorization/CanDownloadLogFileTest.php
@@ -20,8 +20,8 @@ function assertCanDownloadFile(string $fileName): void
 
 function assertCannotDownloadFile(string $fileName): void
 {
-get(route('log-viewer.files.request-download', $fileName))
-->assertForbidden();
+    get(route('log-viewer.files.request-download', $fileName))
+        ->assertForbidden();
 }
 
 test('can download every file by default', function () {
@@ -31,9 +31,9 @@ test('can download every file by default', function () {
 });
 
 test('cannot download a file that\'s not found', function () {
-get(route('log-viewer.files.request-download', 'notfound.log'))
-->assertNotFound();
-    });
+    get(route('log-viewer.files.request-download', 'notfound.log'))
+        ->assertNotFound();
+});
 
 test('"downloadLogFile" gate can prevent file download', function () {
     generateLogFiles([$fileName = 'laravel.log']);

--- a/tests/Feature/Authorization/CanViewLogViewerTest.php
+++ b/tests/Feature/Authorization/CanViewLogViewerTest.php
@@ -6,7 +6,7 @@ use Opcodes\LogViewer\Facades\LogViewer;
 use function Pest\Laravel\get;
 
 test('can define an "auth" callback for authorization', function () {
-get(route('log-viewer.index'))->assertOk();
+    get(route('log-viewer.index'))->assertOk();
 
     // with the gate defined and a false value, it should not be possible to access the log viewer
     LogViewer::auth(fn ($request) => false);
@@ -15,7 +15,7 @@ get(route('log-viewer.index'))->assertOk();
     // now let's give them access
     LogViewer::auth(fn ($request) => true);
     get(route('log-viewer.index'))->assertOk();
-    });
+});
 
 test('the "auth" callback is given with a Request object to check against', function () {
     LogViewer::auth(function ($request) {
@@ -28,14 +28,14 @@ test('the "auth" callback is given with a Request object to check against', func
 });
 
 test('can define a "viewLogViewer" gate as an alternative', function () {
-get(route('log-viewer.index'))->assertOk();
+    get(route('log-viewer.index'))->assertOk();
 
     Gate::define('viewLogViewer', fn ($user = null) => false);
     get(route('log-viewer.index'))->assertForbidden();
 
     Gate::define('viewLogViewer', fn ($user = null) => true);
     get(route('log-viewer.index'))->assertOk();
-    });
+});
 
 test('local environment can use Log Viewer by default', function () {
     app()->detectEnvironment(fn () => 'local');

--- a/tests/Feature/LogsControllerTest.php
+++ b/tests/Feature/LogsControllerTest.php
@@ -61,3 +61,30 @@ test('unicode characters can be searched case-insensitive', function () {
     ]));
     expect($response->json('logs'))->toHaveCount(4);
 });
+
+test('logs include full_text property by default', function () {
+    $logEntries = [
+        makeLaravelLogEntry(message: 'Test message'),
+    ];
+    $file = generateLogFile('log_with_full_text.log', implode(PHP_EOL, $logEntries));
+
+    $response = getJson(route('log-viewer.logs', ['file' => $file->identifier]));
+
+    expect($response->json('logs'))->toHaveCount(1);
+    expect($response->json('logs.0'))->toHaveKey('full_text');
+});
+
+test('logs can exclude full_text property when requested', function () {
+    $logEntries = [
+        makeLaravelLogEntry(message: 'Test message'),
+    ];
+    $file = generateLogFile('log_without_full_text.log', implode(PHP_EOL, $logEntries));
+
+    $response = getJson(route('log-viewer.logs', [
+        'file' => $file->identifier,
+        'exclude_full_text' => true,
+    ]));
+
+    expect($response->json('logs'))->toHaveCount(1);
+    expect($response->json('logs.0'))->not->toHaveKey('full_text');
+});


### PR DESCRIPTION
Implements https://github.com/opcodesio/log-viewer/issues/429

This PR makes it possible to exclude the `full_text` attribute from the log entry response by adding `exclude_full_text=true` to the query param when fetching logs.