### PR TITLE
Add support for custom log datetime format

### DIFF
--- a/config/log-viewer.php
+++ b/config/log-viewer.php
@@ -65,6 +65,16 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Log Viewer datetime format.
+    |--------------------------------------------------------------------------
+    | The format used to display timestamps in the UI.
+    |
+    */
+
+    'datetime_format' => 'Y-m-d H:i:s',
+
+    /*
+    |--------------------------------------------------------------------------
     | Log Viewer route middleware.
     |--------------------------------------------------------------------------
     | Optional middleware to use when loading the initial Log Viewer page.

--- a/src/Http/Resources/LogResource.php
+++ b/src/Http/Resources/LogResource.php
@@ -25,7 +25,7 @@ class LogResource extends JsonResource
             'level_name' => $level->getName(),
             'level_class' => $level->getClass()->value,
 
-            'datetime' => $this->datetime?->toDateTimeString(),
+            'datetime' => $this->datetime?->format(config('log-viewer.datetime_format', 'Y-m-d H:i:s')),
             'time' => $this->datetime?->format('H:i:s'),
             'message' => $this->message,
             'context' => $this->context,


### PR DESCRIPTION
It's very convenient to use a custom date format when working with logs.
Personally, I often rely on microseconds for more precise timestamps (`Y-m-d H:i:s.u`)