### PR TITLE
Fix issue with out of bounds log index

### DIFF
--- a/src/Readers/IndexedLogReader.php
+++ b/src/Readers/IndexedLogReader.php
@@ -236,9 +236,9 @@ class IndexedLogReader extends BaseLogReader implements LogReaderInterface
     {
         $page = $page ?: Paginator::resolveCurrentPage('page');
 
-        if (! is_null($this->onlyShowIndex)) {
+        if (! is_null($this->onlyShowIndex) && $index = $this->reset()->getLogAtIndex($this->onlyShowIndex)) {
             return new LengthAwarePaginator(
-                [$this->reset()->getLogAtIndex($this->onlyShowIndex)],
+                [$index],
                 1,
                 $perPage,
                 $page
@@ -291,7 +291,9 @@ class IndexedLogReader extends BaseLogReader implements LogReaderInterface
 
     protected function getLogAtIndex(int $index): ?Log
     {
-        $position = $this->index()->getPositionForIndex($index);
+        if (! $position = $this->index()->getPositionForIndex($index)) {
+            return null;
+        }
 
         $text = $this->getLogTextAtPosition($position);
 


### PR DESCRIPTION
See https://github.com/opcodesio/log-viewer/discussions/451

This fixes the issue, but I'm not sure what the desired behaviour should be when requesting an index that is too high. Ideally there should be some kind of indication.