### PR TITLE
Feature: laravel.log summary

### DIFF
--- a/src/Console/Commands/LogSummaryCommand.php
+++ b/src/Console/Commands/LogSummaryCommand.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Opcodes\LogViewer\Facades\LogViewer;
+use Opcodes\LogViewer\LogFileCollection;
+
+class LogSummaryCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'log:summary';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Generates a summary of the logs';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): void
+    {
+        static::deleteSummaryFile();
+        $this->comment('Deleted error log summary file');
+        $this->comment('Generating error log summary file');
+        static::generateSummaryFile();
+        $this->comment('Done');
+    }
+
+    protected static function deleteSummaryFile(): void
+    {
+        Storage::disk('logs')
+            ->delete('log-summary.log');
+    }
+
+    protected static function generateSummaryFile(): void
+    {
+        $summary = [];
+
+        /** @var LogFileCollection $files */
+        $files = LogViewer::getFiles();
+
+        foreach ($files as $file) {
+            if ($file->name === 'log-summary.log') {
+                continue;
+            }
+
+            $paginator = $file
+                ->logs()
+                ->paginate(1000);
+
+            foreach ($paginator->items() as $log) {
+                $level = strtoupper($log->level);
+                $message = $log->getOriginalText();
+                $context = $log->context;
+                $env = $log->extra['environment'];
+                $ts = $log->datetime->format('Y-m-d H:i:s');
+
+                if (! isset($summary[$message])) {
+                    $summary[$message] = [
+                        'first' => $ts,
+                        'last'  => $ts,
+                        'count' => 1,
+                        'level' => $level,
+                        'context' => $context,
+                        'env' => $env,
+                    ];
+                } else {
+                    $summary[$message]['count']++;
+                    $summary[$message]['last'] = max(
+                        $ts,
+                        $summary[$message]['last']
+                    );
+                    $summary[$message]['first'] = min(
+                        $ts,
+                        $summary[$message]['first']
+                    );
+                }
+            }
+        }
+
+        $lines = [];
+        foreach ($summary as $message => $data) {
+            $lines[] = trim(sprintf(
+                '[%s] - [%s] %s.%s: %d | %s %s',
+                $data['first'],
+                $data['last'],
+                $data['env'],
+                $data['level'],
+                $data['count'],
+                $message,
+                count($data['context']) > 0 ? Str::replace('\\n', "\n", '\n' . json_encode($data['context'], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)) : ''
+            ));
+
+        }
+
+        Storage::disk('logs')
+            ->put('log-summary.log', implode("\n", $lines));
+    }
+}

--- a/src/Logs/LogSummary.php
+++ b/src/Logs/LogSummary.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace App\Logs;
+
+use Carbon\Carbon;
+use Opcodes\LogViewer\Facades\LogViewer;
+use Opcodes\LogViewer\Logs\Log;
+use Str;
+
+class LogSummary extends Log
+{
+    public static string $name = 'Log Summary';
+
+    public static string $regex = '/^\[(?P<first_datetime>[^\]]+)\]\s*-\s*\[(?P<datetime>[^\]]+)\]\s+(?P<environment>\S+)\.(?P<level>\S+):\s+(?P<count>\d+)\s*\|\s*(?<message>.*)/x';
+
+    public static array $columns = [
+        ['label' => 'Severity', 'data_path' => 'level'],
+        ['label' => 'First', 'data_path' => 'extra.first_datetime'],
+        ['label' => 'Last', 'data_path' => 'datetime'],
+        ['label' => 'Env', 'data_path' => 'extra.environment'],
+        ['label' => 'Count', 'data_path' => 'extra.count'],
+        ['label' => 'Message', 'data_path' => 'message'],
+    ];
+
+    public static string $regexFirstDatetimeKey = 'first_datetime';
+    public static string $regexCountKey = 'count';
+    public static string $regexEnvironmentKey = 'environment';
+
+    public function fillMatches(array $matches = []): void
+    {
+        parent::fillMatches($matches);
+
+        $this->message = $matches[static::$regexMessageKey] ?? '';
+        $this->extra = [
+            'environment' => $matches[static::$regexEnvironmentKey] ?? '',
+            'count' => $matches[static::$regexCountKey] ?? 0,
+            'first_datetime' => Carbon::parse($matches[static::$regexFirstDatetimeKey] ?? '')
+                ->setTimezone(LogViewer::timezone())
+                ->format("Y\u{2011}m\u{2011}d\u{00A0}H:i:s"),
+        ];
+
+
+        $raw = $this->text;
+
+        if (preg_match('/\{".*}/s', $raw, $m)) {
+            $jsonString = $m[0];
+            $pos = Str::position($raw, '{"');
+            if ($pos !== false) {
+                $cleanText = substr($raw, 0, $pos);
+                $this->text = $cleanText;
+            }
+
+            $escaped = $this->sanitizeJson($jsonString);
+
+            $contextArray = json_decode($escaped, true);
+
+            if (json_last_error() !== JSON_ERROR_NONE) {
+                $contextArray = [];
+            }
+        } else {
+            $contextArray = [];
+        }
+
+        $this->context = $contextArray;
+    }
+
+    public function getOriginalText(): ?string
+    {
+        if (! $this->text) {
+            return null;
+        }
+
+        $pos = Str::position($this->text, '| ');
+        if ($pos === false) {
+            return $this->text;
+        }
+
+        return Str::substr($this->text, $pos + 2);
+    }
+
+    protected function sanitizeJson(string $json): string
+    {
+        return Str::replace(
+            ["\n", "\t"],
+            ['\\n', '\\t'],
+            $json
+        );
+    }
+}


### PR DESCRIPTION
Hello, I developed this feature that we will being used in multiple projects, so I figured I'd submit a PR to the package and see what others think.

# What's New:
- Added a new command `log-viewer:summary` which will take the last 1000 logs in laravel.log, count them, keep track of the first and last dates each one was logged, and create a new `log-summary.log` file
- Added a new LogSummary class that extends Log.php in order to display the summary in the Log Viewer

Note that a Laravel project will still need to have 
```
LogViewer::extend('log_summary', \Opcodes\LogViewer\Logs\LogSummary::class);
```
in AppServiceProvider.php in order for this feature work. I wasn't sure if there is a way to include this into the PR to avoid this. Please let me know if this can be added or if any other alterations should be made.