### PR TITLE
Fix LogFileCollection sorting to use idiomatic Laravel .all() method

### DIFF
--- a/src/LogFileCollection.php
+++ b/src/LogFileCollection.php
@@ -30,14 +30,14 @@ class LogFileCollection extends Collection
 
     public function sortAlphabeticallyAsc(): self
     {
-        $this->items = $this->sortBy('name')->values()->toArray();
+        $this->items = $this->sortBy('name')->values()->all();
 
         return $this;
     }
 
     public function sortAlphabeticallyDesc(): self
     {
-        $this->items = $this->sortByDesc('name')->values()->toArray();
+        $this->items = $this->sortByDesc('name')->values()->all();
 
         return $this;
     }

--- a/src/LogFolderCollection.php
+++ b/src/LogFolderCollection.php
@@ -18,14 +18,14 @@ class LogFolderCollection extends Collection
 
     public function sortByEarliestFirst(): self
     {
-        $this->items = $this->sortBy->earliestTimestamp()->values()->toArray();
+        $this->items = $this->sortBy->earliestTimestamp()->values()->all();
 
         return $this;
     }
 
     public function sortByLatestFirst(): self
     {
-        $this->items = $this->sortByDesc->latestTimestamp()->values()->toArray();
+        $this->items = $this->sortByDesc->latestTimestamp()->values()->all();
 
         return $this;
     }
@@ -60,7 +60,7 @@ class LogFolderCollection extends Collection
                 return strcmp($a->cleanPath(), $b->cleanPath());
             })
             ->values()
-            ->toArray();
+            ->all();
 
         return $this;
     }
@@ -79,7 +79,7 @@ class LogFolderCollection extends Collection
                 return strcmp($b->cleanPath(), $a->cleanPath());
             })
             ->values()
-            ->toArray();
+            ->all();
 
         return $this;
     }


### PR DESCRIPTION
## Summary
- Replace `.toArray()` with `.all()` in `sortByEarliestFirst()` and `sortByLatestFirst()` methods
- Preserves Collection type consistency and maintains idiomatic Laravel patterns
- `.all()` is the preferred method for direct item access, avoiding unnecessary serialization overhead

## Test Plan
✅ All 240 tests pass with the changes

## Details
The original code used `.toArray()` which performs additional formatting and serialization. Using `.all()` is more idiomatic and aligns with how Laravel internally mutates Collections.