### PR TITLE
Remove redundant file sorting in FoldersController

### DIFF
--- a/src/Http/Controllers/FoldersController.php
+++ b/src/Http/Controllers/FoldersController.php
@@ -31,9 +31,9 @@ class FoldersController
             }
         } else { // ModifiedTime
             if ($fileSortingOrder === SortingOrder::Ascending) {
-                $folders = $folders->sortByEarliestFirstIncludingFiles();
+                $folders = $folders->sortByEarliestFirst();
             } else {
-                $folders = $folders->sortByLatestFirstIncludingFiles();
+                $folders = $folders->sortByLatestFirst();
             }
         }
 


### PR DESCRIPTION
## Summary
- Replaced `sortByEarliestFirstIncludingFiles()` with `sortByEarliestFirst()` 
- Replaced `sortByLatestFirstIncludingFiles()` with `sortByLatestFirst()`
- File sorting is already handled by the loop on lines 41-56, making the `IncludingFiles` methods redundant

## Test plan
- All 273 tests pass
- Feature tests verify folder and file sorting behavior remains unchanged