### PR TITLE
Fix assetsAreCurrent to respect assets_path config

### DIFF
--- a/src/LogViewerService.php
+++ b/src/LogViewerService.php
@@ -346,7 +346,7 @@ class LogViewerService
      */
     public function assetsAreCurrent(): bool
     {
-        $publishedPath = public_path('vendor/log-viewer/mix-manifest.json');
+        $publishedPath = public_path(Str::finish(config('log-viewer.assets_path'), '/').'mix-manifest.json');
 
         if (! File::exists($publishedPath)) {
             throw new \RuntimeException('Log Viewer assets are not published. Please run: php artisan vendor:publish --tag=log-viewer-assets --force');

--- a/tests/Unit/AssetsAreCurrentTest.php
+++ b/tests/Unit/AssetsAreCurrentTest.php
@@ -1,0 +1,63 @@
+<?php
+
+use Illuminate\Support\Facades\File;
+use Opcodes\LogViewer\Facades\LogViewer;
+
+beforeEach(function () {
+    // Ensure the source manifest exists
+    File::ensureDirectoryExists(__DIR__.'/../../public');
+    if (! File::exists(__DIR__.'/../../public/mix-manifest.json')) {
+        File::put(__DIR__.'/../../public/mix-manifest.json', '{"test": "source"}');
+    }
+});
+
+test('assetsAreCurrent returns true when published manifest matches source', function () {
+    $publishedPath = public_path('vendor/log-viewer/mix-manifest.json');
+    $sourcePath = __DIR__.'/../../public/mix-manifest.json';
+
+    File::ensureDirectoryExists(dirname($publishedPath));
+    File::copy($sourcePath, $publishedPath);
+
+    expect(LogViewer::assetsAreCurrent())->toBeTrue();
+
+    File::delete($publishedPath);
+});
+
+test('assetsAreCurrent returns false when published manifest differs from source', function () {
+    $publishedPath = public_path('vendor/log-viewer/mix-manifest.json');
+
+    File::ensureDirectoryExists(dirname($publishedPath));
+    File::put($publishedPath, '{"test": "different"}');
+
+    expect(LogViewer::assetsAreCurrent())->toBeFalse();
+
+    File::delete($publishedPath);
+});
+
+test('assetsAreCurrent throws exception when published assets do not exist', function () {
+    $publishedPath = public_path('vendor/log-viewer/mix-manifest.json');
+
+    if (File::exists($publishedPath)) {
+        File::delete($publishedPath);
+    }
+
+    LogViewer::assetsAreCurrent();
+})->throws(
+    RuntimeException::class,
+    'Log Viewer assets are not published. Please run: php artisan vendor:publish --tag=log-viewer-assets --force'
+);
+
+test('assetsAreCurrent respects custom assets_path config', function () {
+    $customPath = 'custom-log-viewer-path';
+    config(['log-viewer.assets_path' => $customPath]);
+
+    $publishedPath = public_path($customPath.'/mix-manifest.json');
+    $sourcePath = __DIR__.'/../../public/mix-manifest.json';
+
+    File::ensureDirectoryExists(dirname($publishedPath));
+    File::copy($sourcePath, $publishedPath);
+
+    expect(LogViewer::assetsAreCurrent())->toBeTrue();
+
+    File::deleteDirectory(public_path($customPath));
+});


### PR DESCRIPTION
## Problem

The `assetsAreCurrent()` method was hardcoded to check for the manifest file at `vendor/log-viewer/mix-manifest.json`, completely ignoring the configurable `assets_path` setting in `config/log-viewer.php`.

This caused issues when users customized their assets path - the method would always look in the wrong location and either:
- Throw an exception saying assets aren't published (even though they were, just in a different location)
- Return false negatives when comparing manifests

## Solution

Updated `LogViewerService::assetsAreCurrent()` to use `config('log-viewer.assets_path')` instead of the hardcoded path, making it consistent with:
- The blade view (`resources/views/index.blade.php`) which already uses the config value
- The service provider's asset publishing logic

## Changes

- Modified `src/LogViewerService.php` to read from configured assets path
- Added comprehensive test suite in `tests/Unit/AssetsAreCurrentTest.php` with 4 test cases:
  - Assets match when published to default location
  - Assets differ when manifests don't match
  - Exception thrown when assets not published
  - **New:** Assets validated correctly at custom configured path

## Test Results

All 304 tests passing ✓