### PR TITLE
Include all laravel-anything.log, laravel-mychannel.log file or etc

### DIFF
--- a/src/LogTypeRegistrar.php
+++ b/src/LogTypeRegistrar.php
@@ -114,6 +114,6 @@ class LogTypeRegistrar
     protected function isPossiblyLaravelLogFile(string $fileName): bool
     {
         return $fileName === 'laravel.log'
-            || preg_match('/laravel-\d{4}-\d{2}-\d{2}\.log/', $fileName);
+            || preg_match('/laravel-[\w\W]*.log/', $fileName);
     }
 }


### PR DESCRIPTION
Include all laravel-anything.log, laravel-mychannel.log file or etc as laravel log file

<img width="616" height="202" alt="image" src="https://github.com/user-attachments/assets/dd0aa5ed-de56-43a6-b0b3-620b8a87840b" />

Some of the files can't be detected through detection. so i forced to do it.