### PR TITLE
Use scoped bindings for Octane compatibility

### DIFF
--- a/src/LogViewerServiceProvider.php
+++ b/src/LogViewerServiceProvider.php
@@ -32,13 +32,15 @@ class LogViewerServiceProvider extends ServiceProvider
     {
         $this->mergeConfigFrom(self::basePath("/config/{$this->name}.php"), $this->name);
 
-        $this->app->scoped('log-viewer', LogViewerService::class);
-        $this->app->scoped('log-viewer-cache', function () {
+        $bindMethod = method_exists($this->app, 'scoped') ? 'scoped' : 'singleton';
+
+        $this->app->$bindMethod('log-viewer', LogViewerService::class);
+        $this->app->$bindMethod('log-viewer-cache', function () {
             return Cache::driver(config('log-viewer.cache_driver'));
         });
 
         if (! $this->app->bound(LogTypeRegistrar::class)) {
-            $this->app->scoped(LogTypeRegistrar::class, function () {
+            $this->app->$bindMethod(LogTypeRegistrar::class, function () {
                 return new LogTypeRegistrar;
             });
         }

--- a/src/LogViewerServiceProvider.php
+++ b/src/LogViewerServiceProvider.php
@@ -32,13 +32,13 @@ class LogViewerServiceProvider extends ServiceProvider
     {
         $this->mergeConfigFrom(self::basePath("/config/{$this->name}.php"), $this->name);
 
-        $this->app->bind('log-viewer', LogViewerService::class);
-        $this->app->bind('log-viewer-cache', function () {
+        $this->app->scoped('log-viewer', LogViewerService::class);
+        $this->app->scoped('log-viewer-cache', function () {
             return Cache::driver(config('log-viewer.cache_driver'));
         });
 
         if (! $this->app->bound(LogTypeRegistrar::class)) {
-            $this->app->singleton(LogTypeRegistrar::class, function () {
+            $this->app->scoped(LogTypeRegistrar::class, function () {
                 return new LogTypeRegistrar;
             });
         }


### PR DESCRIPTION
This PR updates the service container bindings in `LogViewerServiceProvider` from `bind`/`singleton` to `scoped`.

### Why is this change necessary?

When running Log Viewer in a **Laravel Octane** environment (FreankenPHP, Swoole, RoadRunner, etc.), the application container persists between requests. Using standard bindings for services like `LogViewerService` or `LogTypeRegistrar` can cause issues when using **custom resolvers**.

Because the resolver logic often depends on the current request state, using `scoped` ensures that:

1. The service is fresh for every new incoming request.
2. The service still acts as a singleton *within* the lifecycle of that single request (performance efficiency).
3. Stale data or configuration from a previous request doesn't "leak" into the next one.

### Changes

* Changed `log-viewer` binding to `scoped`.
* Changed `log-viewer-cache` binding to `scoped`.
* Changed `LogTypeRegistrar` binding to `scoped`.

---

**References:**

* [Log Viewer - Using a custom resolver](https://log-viewer.opcodes.io/docs/2.x/configuration/multiple-hosts?ref=arunas.dev#using-a-custom-resolver)
* [Laravel Documentation - Scoped Bindings](https://laravel.com/docs/12.x/container#binding-scoped)
* [Laravel Octane - Dependency Injection & Octane](https://www.google.com/search?q=https://laravel.com/docs/12.x/octane%23dependency-injection-and-octane)


---

### Proposed Code Changes

```php
// src/LogViewerServiceProvider.php

-       $this->app->bind('log-viewer', LogViewerService::class);
-       $this->app->bind('log-viewer-cache', function () {
+       $this->app->scoped('log-viewer', LogViewerService::class);
+       $this->app->scoped('log-viewer-cache', function () {
            return Cache::driver(config('log-viewer.cache_driver'));
        });

        if (! $this->app->bound(LogTypeRegistrar::class)) {
-           $this->app->singleton(LogTypeRegistrar::class, function () {
+           $this->app->scoped(LogTypeRegistrar::class, function () {
                return new LogTypeRegistrar;
            });
        }

```

### Octane Use Case / Reproduction

In a Laravel Octane environment, the Application container is booted once and stays in memory. When using a custom host resolver like the one below, standard `bind` or `singleton` registrations can cause the `LogViewerService` to hold onto state from the very first request that initialized it.

```php
/**
 * In a ServiceProvider boot method
 */
public function boot()
{
    // If 'log-viewer' is not scoped, Octane may reuse the service instance
    // across different requests, potentially ignoring runtime changes 
    // or request-specific logic inside this resolver.
    LogViewer::resolveHostsUsing(function (HostCollection $hosts) {
        return [
            'local' => [
                'name' => 'Local logs',
            ],
            'staging' => [
                'name' => 'Staging server',
                'host' => 'https://staging.example.com/log-viewer',
            ],
        ];
    });
}

```

By switching to `$this->app->scoped()`, we guarantee that the `LogViewerService` is re-resolved from the container at the start of every Octane "sandbox" request, while still maintaining singleton-like behavior within the duration of that single request.

